### PR TITLE
Reformulate the explanation of type vs value passing in the API

### DIFF
--- a/example/intro.cpp
+++ b/example/intro.cpp
@@ -42,13 +42,12 @@ int main() {
     using expected_function_type = void(int, int&&, const int&, void*);
     static_assert(std::is_same<function_type, expected_function_type>::value, "");
 
-    // By design, the ``[libname]`` interface uses constexpr
-    // std::integral_constant functions (whenever sensible).
-    // By also defining the appropriate overloads, this gives
-    // users the option of using either type arguments or a value
-    // arguments, which often eliminates the need for decltype:
-    static_assert(ct::arity<foo>() == 4, "");
-    static_assert(ct::arity(foo{}) == 4, "");
+    // By design, the ``[libname]`` interface uses constexpr functions accepting
+    // objects and returning std::integral_constants (whenever sensible). However,
+    // for those times where you don't have an object at hand, you can also pass 
+    // the type of that object only:
+    static_assert(ct::arity(foo{}) == 4, ""); // with object
+    static_assert(ct::arity<foo>() == 4, ""); // with type
 
     // Attentive readers might notice that the type of the foo{}
     // expression above is foo&&, rather than foo. Indeed,


### PR DESCRIPTION
I thought that not everybody would get the "_which often eliminates the need for decltype_" part. It's not merely a reformulation, it also brings the rationale from a slightly different angle ("when you don't have an object at hand, etc.."). But if this is not __what__ you want to say, disregard my suggestion.